### PR TITLE
During Game + Player/Game State

### DIFF
--- a/lib/features/game/models/game_model.dart
+++ b/lib/features/game/models/game_model.dart
@@ -30,10 +30,37 @@ abstract class GameModel with _$GameModel {
 
   factory GameModel.fromFirestore(DocumentSnapshot doc) {
     final data = doc.data() as Map<String, dynamic>;
-    return GameModel.fromJson({
+    
+    // Convert Firestore timestamps to ISO string format for JSON serialization
+    final convertedData = <String, dynamic>{
       'id': doc.id,
       ...data,
-    });
+    };
+    
+    // Handle createdAt timestamp - convert to ISO string
+    if (convertedData['createdAt'] is Timestamp) {
+      final dateTime = (convertedData['createdAt'] as Timestamp).toDate();
+      convertedData['createdAt'] = dateTime.toIso8601String();
+      print('Converted createdAt: ${convertedData['createdAt']}'); // Debug log
+    }
+    
+    // Handle startedAt timestamp - convert to ISO string
+    if (convertedData['startedAt'] is Timestamp) {
+      final dateTime = (convertedData['startedAt'] as Timestamp).toDate();
+      convertedData['startedAt'] = dateTime.toIso8601String();
+      print('Converted startedAt: ${convertedData['startedAt']}'); // Debug log
+    }
+    
+    // Handle endedAt timestamp - convert to ISO string
+    if (convertedData['endedAt'] is Timestamp) {
+      final dateTime = (convertedData['endedAt'] as Timestamp).toDate();
+      convertedData['endedAt'] = dateTime.toIso8601String();
+      print('Converted endedAt: ${convertedData['endedAt']}'); // Debug log
+    }
+    
+    print('Converted data before JSON parsing: $convertedData'); // Debug log
+    
+    return GameModel.fromJson(convertedData);
   }
 }
 

--- a/lib/features/game/pages/during_game_page.dart
+++ b/lib/features/game/pages/during_game_page.dart
@@ -1,0 +1,502 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import '../../../core/services/venmo_service.dart';
+import '../models/game_model.dart';
+import '../models/player_model.dart';
+
+class DuringGamePage extends StatefulWidget {
+  final GameModel game;
+  final PlayerModel currentPlayer;
+
+  const DuringGamePage({
+    super.key,
+    required this.game,
+    required this.currentPlayer,
+  });
+
+  @override
+  State<DuringGamePage> createState() => _DuringGamePageState();
+}
+
+class _DuringGamePageState extends State<DuringGamePage> {
+  final _topOffController = TextEditingController();
+  final _venmoUsernameController = TextEditingController();
+  bool _isProcessingPayment = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _topOffController.text = widget.game.buyIn.toString();
+    if (widget.game.venmoUsername != null) {
+      _venmoUsernameController.text = widget.game.venmoUsername!;
+    }
+  }
+
+  @override
+  void dispose() {
+    _topOffController.dispose();
+    _venmoUsernameController.dispose();
+    super.dispose();
+  }
+
+  int get _totalBuyIns => widget.game.players.fold(0, (sum, player) => sum + player.inFor);
+
+  Future<void> _handleTopOff() async {
+    if (_topOffController.text.trim().isEmpty) {
+      _showErrorSnackBar('Please enter a top-off amount');
+      return;
+    }
+
+    final amount = int.tryParse(_topOffController.text);
+    if (amount == null || amount <= 0) {
+      _showErrorSnackBar('Please enter a valid amount');
+      return;
+    }
+
+    if (widget.game.venmoUsername == null || widget.game.venmoUsername!.isEmpty) {
+      _showErrorSnackBar('Host has not set their Venmo username');
+      return;
+    }
+
+    setState(() {
+      _isProcessingPayment = true;
+    });
+
+    try {
+      final success = await VenmoService.launchVenmoTransaction(
+        venmoUsername: widget.game.venmoUsername!,
+        amount: amount.toDouble(),
+        note: 'Poker game top-off - ${widget.game.id}',
+        context: context,
+        transactionType: VenmoTransactionType.pay,
+      );
+
+      if (success) {
+        _showSuccessSnackBar('Venmo opened for payment of \$${amount.toStringAsFixed(2)}');
+      } else {
+        _showErrorSnackBar('Failed to open Venmo. Please try again.');
+      }
+    } catch (e) {
+      _showErrorSnackBar('Error: $e');
+    } finally {
+      setState(() {
+        _isProcessingPayment = false;
+      });
+    }
+  }
+
+  void _showTopOffDialog() {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Add Buy-in / Top-off'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextField(
+              controller: _topOffController,
+              decoration: const InputDecoration(
+                labelText: 'Amount (\$)',
+                border: OutlineInputBorder(),
+                prefixIcon: Icon(Icons.attach_money),
+              ),
+              keyboardType: TextInputType.number,
+              inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+            ),
+            const SizedBox(height: 16),
+            if (widget.game.venmoUsername != null) ...[
+              TextField(
+                controller: _venmoUsernameController,
+                decoration: const InputDecoration(
+                  labelText: 'Host Venmo Username',
+                  border: OutlineInputBorder(),
+                  prefixIcon: Icon(Icons.payment),
+                ),
+                enabled: false, // Read-only since it's set by host
+              ),
+            ] else ...[
+              const Text(
+                'Host has not set their Venmo username',
+                style: TextStyle(color: Colors.red),
+              ),
+            ],
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Cancel'),
+          ),
+          ElevatedButton(
+            onPressed: widget.game.venmoUsername != null ? _handleTopOff : null,
+            child: _isProcessingPayment
+                ? const SizedBox(
+                    width: 20,
+                    height: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Text('Pay via Venmo'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _showEndGameDialog() {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('End Game'),
+        content: const Text('Are you sure you want to end the game for all players?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Cancel'),
+          ),
+          ElevatedButton(
+            onPressed: () {
+              Navigator.of(context).pop();
+              // TODO: Implement end game functionality
+              _showSuccessSnackBar('Game ended successfully');
+            },
+            style: ElevatedButton.styleFrom(backgroundColor: Colors.red),
+            child: const Text('End Game'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _showLeaveGameDialog() {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Leave Game'),
+        content: const Text('Are you sure you want to leave this game?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Cancel'),
+          ),
+          ElevatedButton(
+            onPressed: () {
+              Navigator.of(context).pop();
+              // TODO: Implement leave game functionality
+              Navigator.of(context).pop(); // Go back to main page
+              _showSuccessSnackBar('Left game successfully');
+            },
+            style: ElevatedButton.styleFrom(backgroundColor: Colors.red),
+            child: const Text('Leave Game'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _showErrorSnackBar(String message) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(message),
+        backgroundColor: Colors.red,
+      ),
+    );
+  }
+
+  void _showSuccessSnackBar(String message) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(message),
+        backgroundColor: Colors.green,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Game: ${widget.game.id}'),
+        backgroundColor: widget.currentPlayer.isHost ? Colors.green[700] : Colors.blue[700],
+        foregroundColor: Colors.white,
+        actions: [
+          if (widget.currentPlayer.isHost)
+            IconButton(
+              onPressed: _showEndGameDialog,
+              icon: const Icon(Icons.stop),
+              tooltip: 'End Game',
+            )
+          else
+            IconButton(
+              onPressed: _showLeaveGameDialog,
+              icon: const Icon(Icons.exit_to_app),
+              tooltip: 'Leave Game',
+            ),
+        ],
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            // Game Stats Card
+            Card(
+              elevation: 4,
+              child: Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Game Stats',
+                      style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceAround,
+                      children: [
+                        _buildStatItem(
+                          icon: Icons.group,
+                          label: 'Players',
+                          value: '${widget.game.currentPlayers}/${widget.game.maxPlayers}',
+                        ),
+                        _buildStatItem(
+                          icon: Icons.attach_money,
+                          label: 'Total Buy-ins',
+                          value: '\$${_totalBuyIns.toStringAsFixed(0)}',
+                        ),
+                        _buildStatItem(
+                          icon: Icons.casino,
+                          label: 'Buy-in',
+                          value: '\$${widget.game.buyIn}',
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+
+            // Players List
+            Expanded(
+              child: Card(
+                elevation: 4,
+                child: Padding(
+                  padding: const EdgeInsets.all(16.0),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Players',
+                        style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      const SizedBox(height: 16),
+                      Expanded(
+                        child: ListView.builder(
+                          itemCount: widget.game.players.length,
+                          itemBuilder: (context, index) {
+                            final player = widget.game.players[index];
+                            return _buildPlayerTile(player);
+                          },
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+
+            // Action Buttons
+            Row(
+              children: [
+                Expanded(
+                  child: ElevatedButton.icon(
+                    onPressed: _showTopOffDialog,
+                    icon: const Icon(Icons.add),
+                    label: const Text('Add Buy-in'),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.green[700],
+                      foregroundColor: Colors.white,
+                      padding: const EdgeInsets.symmetric(vertical: 16),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 16),
+                if (widget.currentPlayer.isHost)
+                  Expanded(
+                    child: ElevatedButton.icon(
+                      onPressed: _showEndGameDialog,
+                      icon: const Icon(Icons.stop),
+                      label: const Text('End Game'),
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: Colors.red[700],
+                        foregroundColor: Colors.white,
+                        padding: const EdgeInsets.symmetric(vertical: 16),
+                      ),
+                    ),
+                  )
+                else
+                  Expanded(
+                    child: ElevatedButton.icon(
+                      onPressed: _showLeaveGameDialog,
+                      icon: const Icon(Icons.exit_to_app),
+                      label: const Text('Leave Game'),
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: Colors.red[700],
+                        foregroundColor: Colors.white,
+                        padding: const EdgeInsets.symmetric(vertical: 16),
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildStatItem({
+    required IconData icon,
+    required String label,
+    required String value,
+  }) {
+    return Column(
+      children: [
+        Icon(icon, size: 32, color: Colors.blue[700]),
+        const SizedBox(height: 8),
+        Text(
+          value,
+          style: const TextStyle(
+            fontSize: 18,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        Text(
+          label,
+          style: TextStyle(
+            fontSize: 12,
+            color: Colors.grey[600],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildPlayerTile(PlayerModel player) {
+    final isCurrentPlayer = player.id == widget.currentPlayer.id;
+    
+    return Container(
+      margin: const EdgeInsets.only(bottom: 8),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: isCurrentPlayer ? Colors.blue[50] : Colors.grey[50],
+        border: Border.all(
+          color: isCurrentPlayer ? Colors.blue : Colors.grey[300]!,
+          width: isCurrentPlayer ? 2 : 1,
+        ),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          CircleAvatar(
+            backgroundColor: player.isHost ? Colors.green[700] : Colors.blue[700],
+            child: Text(
+              player.name[0].toUpperCase(),
+              style: const TextStyle(
+                color: Colors.white,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Text(
+                      player.name,
+                      style: const TextStyle(
+                        fontWeight: FontWeight.bold,
+                        fontSize: 16,
+                      ),
+                    ),
+                    if (player.isHost) ...[
+                      const SizedBox(width: 8),
+                      Container(
+                        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                        decoration: BoxDecoration(
+                          color: Colors.green[700],
+                          borderRadius: BorderRadius.circular(4),
+                        ),
+                        child: const Text(
+                          'HOST',
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontSize: 10,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ),
+                    ],
+                    if (isCurrentPlayer) ...[
+                      const SizedBox(width: 8),
+                      Container(
+                        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                        decoration: BoxDecoration(
+                          color: Colors.blue[700],
+                          borderRadius: BorderRadius.circular(4),
+                        ),
+                        child: const Text(
+                          'YOU',
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontSize: 10,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+                const SizedBox(height: 4),
+                Row(
+                  children: [
+                    Text(
+                      'In for: \$${player.inFor}',
+                      style: TextStyle(
+                        color: Colors.grey[700],
+                        fontSize: 14,
+                      ),
+                    ),
+                    const SizedBox(width: 16),
+                    Icon(
+                      player.isOnline ? Icons.circle : Icons.circle_outlined,
+                      color: player.isOnline ? Colors.green : Colors.red,
+                      size: 12,
+                    ),
+                    const SizedBox(width: 4),
+                    Text(
+                      player.isOnline ? 'Online' : 'Offline',
+                      style: TextStyle(
+                        color: player.isOnline ? Colors.green : Colors.red,
+                        fontSize: 12,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/game/provider/game_provider.dart
+++ b/lib/features/game/provider/game_provider.dart
@@ -1,7 +1,9 @@
+import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import '../../../../core/services/firebase_service.dart';
 import '../../../../core/utils/game_id_generator.dart';
+import '../../../../core/utils/validators.dart';
 import '../models/game_model.dart';
 import '../models/player_model.dart';
 
@@ -11,10 +13,12 @@ class GameProvider extends ChangeNotifier {
   GameProvider(this._firebaseService);
 
   GameModel? _currentGame;
+  String? _currentGameId;
   bool _isLoading = false;
   String? _error;
 
   GameModel? get currentGame => _currentGame;
+  String? get currentGameId => _currentGameId;
   bool get isLoading => _isLoading;
   String? get error => _error;
 
@@ -25,6 +29,7 @@ class GameProvider extends ChangeNotifier {
     required int buyIn,
     required int maxPlayers,
     required GameType type,
+    String? venmoUsername,
   }) async {
     _setLoading(true);
     _clearError();
@@ -66,6 +71,7 @@ class GameProvider extends ChangeNotifier {
         'buyIn': buyIn,
         'createdAt': FieldValue.serverTimestamp(),
         'gameState': {},
+        if (venmoUsername != null && venmoUsername.isNotEmpty) 'venmoUsername': venmoUsername,
       };
 
       await _firebaseService.games.doc(gameId).set(gameData);
@@ -148,6 +154,250 @@ class GameProvider extends ChangeNotifier {
     });
   }
 
+  // Start listening to game updates (for real-time sync)
+  StreamSubscription<DocumentSnapshot>? _gameSubscription;
+  
+  void startListeningToGame(String gameId) {
+    _gameSubscription?.cancel();
+    _currentGameId = gameId; // Store the current game ID
+    final gameRef = _firebaseService.games.doc(gameId);
+    
+    print('Starting to listen to game: $gameId'); // Debug log
+    
+    _gameSubscription = gameRef.snapshots().listen(
+      (snapshot) {
+        print('Game snapshot received for $gameId: exists=${snapshot.exists}'); // Debug log
+        if (snapshot.exists) {
+          try {
+            print('Raw Firestore data: ${snapshot.data()}'); // Debug log
+            _currentGame = GameModel.fromFirestore(snapshot);
+            print('Game data loaded successfully: ${_currentGame?.id}'); // Debug log
+            notifyListeners();
+          } catch (e, stackTrace) {
+            print('Error parsing game data: $e'); // Debug log
+            print('Stack trace: $stackTrace'); // Debug log
+            _setError('Failed to parse game data: $e');
+          }
+        } else {
+          print('Game document does not exist: $gameId'); // Debug log
+          _setError('Game not found');
+        }
+      },
+      onError: (error) {
+        print('Game listener error: $error'); // Debug log
+        _setError('Failed to sync game state: $error');
+      },
+    );
+  }
+
+  // Stop listening to game updates
+  void stopListeningToGame() {
+    _gameSubscription?.cancel();
+    _gameSubscription = null;
+  }
+
+  // Restart listening to current game
+  void restartListening() {
+    if (_currentGameId != null) {
+      startListeningToGame(_currentGameId!);
+    }
+  }
+
+  // Debug method to check provider state
+  void debugState() {
+    print('GameProvider Debug State:');
+    print('  - currentGameId: $_currentGameId');
+    print('  - currentGame: ${_currentGame?.id}');
+    print('  - isLoading: $_isLoading');
+    print('  - error: $_error');
+    print('  - hasSubscription: ${_gameSubscription != null}');
+  }
+
+  // End game (host only)
+  Future<bool> endGame(String gameId) async {
+    _setLoading(true);
+    _clearError();
+
+    try {
+      final gameRef = _firebaseService.games.doc(gameId);
+      await gameRef.update({
+        'status': GameStatus.finished.name,
+        'endedAt': FieldValue.serverTimestamp(),
+      });
+
+      _setLoading(false);
+      return true;
+    } catch (e) {
+      _setError(e.toString());
+      return false;
+    }
+  }
+
+  // Leave game (player only)
+  Future<bool> leaveGame(String gameId, String playerId) async {
+    _setLoading(true);
+    _clearError();
+
+    try {
+      final gameRef = _firebaseService.games.doc(gameId);
+      final gameDoc = await gameRef.get();
+
+      if (!gameDoc.exists) {
+        throw Exception('Game not found');
+      }
+
+      final gameData = gameDoc.data() as Map<String, dynamic>;
+      final players = List<Map<String, dynamic>>.from(gameData['players']);
+      
+      // Remove player from the list
+      players.removeWhere((player) => player['id'] == playerId);
+      
+      await gameRef.update({
+        'players': players,
+        'currentPlayers': players.length,
+      });
+
+      _setLoading(false);
+      return true;
+    } catch (e) {
+      _setError(e.toString());
+      return false;
+    }
+  }
+
+  // Update player status (online/offline)
+  Future<bool> updatePlayerStatus(String gameId, String playerId, bool isOnline) async {
+    try {
+      final gameRef = _firebaseService.games.doc(gameId);
+      final gameDoc = await gameRef.get();
+
+      if (!gameDoc.exists) {
+        throw Exception('Game not found');
+      }
+
+      final gameData = gameDoc.data() as Map<String, dynamic>;
+      final players = List<Map<String, dynamic>>.from(gameData['players']);
+      
+      // Find and update player
+      final playerIndex = players.indexWhere((player) => player['id'] == playerId);
+      if (playerIndex != -1) {
+        players[playerIndex]['isOnline'] = isOnline;
+        
+        await gameRef.update({
+          'players': players,
+        });
+        return true;
+      }
+      
+      return false;
+    } catch (e) {
+      _setError(e.toString());
+      return false;
+    }
+  }
+
+  // Update player buy-in amount
+  Future<bool> updatePlayerBuyIn(String gameId, String playerId, int newAmount) async {
+    try {
+      final gameRef = _firebaseService.games.doc(gameId);
+      final gameDoc = await gameRef.get();
+
+      if (!gameDoc.exists) {
+        throw Exception('Game not found');
+      }
+
+      final gameData = gameDoc.data() as Map<String, dynamic>;
+      final players = List<Map<String, dynamic>>.from(gameData['players']);
+      
+      // Find and update player
+      final playerIndex = players.indexWhere((player) => player['id'] == playerId);
+      if (playerIndex != -1) {
+        players[playerIndex]['inFor'] = newAmount;
+        
+        await gameRef.update({
+          'players': players,
+        });
+        return true;
+      }
+      
+      return false;
+    } catch (e) {
+      _setError(e.toString());
+      return false;
+    }
+  }
+
+  // Set Venmo username (host only)
+  Future<bool> setVenmoUsername(String gameId, String venmoUsername) async {
+    try {
+      final gameRef = _firebaseService.games.doc(gameId);
+      await gameRef.update({
+        'venmoUsername': venmoUsername,
+      });
+      return true;
+    } catch (e) {
+      _setError(e.toString());
+      return false;
+    }
+  }
+
+  // Update Venmo username (host only) - with validation
+  Future<bool> updateVenmoUsername(String gameId, String venmoUsername) async {
+    if (venmoUsername.trim().isEmpty) {
+      _setError('Venmo username cannot be empty');
+      return false;
+    }
+    
+    if (!isValidVenmoUsername(venmoUsername.trim())) {
+      _setError('Please enter a valid Venmo username (3-16 characters, alphanumeric and underscores only)');
+      return false;
+    }
+    
+    return await setVenmoUsername(gameId, venmoUsername.trim());
+  }
+
+  // Manually fetch game data (fallback method)
+  Future<bool> fetchGame(String gameId) async {
+    _setLoading(true);
+    _clearError();
+    
+    try {
+      final gameRef = _firebaseService.games.doc(gameId);
+      final snapshot = await gameRef.get();
+      
+      if (snapshot.exists) {
+        print('Fetching game data for: $gameId'); // Debug log
+        print('Raw Firestore data: ${snapshot.data()}'); // Debug log
+        _currentGame = GameModel.fromFirestore(snapshot);
+        print('Game data fetched successfully: ${_currentGame?.id}'); // Debug log
+        _setLoading(false);
+        notifyListeners();
+        return true;
+      } else {
+        print('Game document does not exist when fetching: $gameId'); // Debug log
+        _setError('Game not found');
+        _setLoading(false);
+        return false;
+      }
+    } catch (e, stackTrace) {
+      print('Error fetching game data: $e'); // Debug log
+      print('Stack trace: $stackTrace'); // Debug log
+      _setError('Failed to fetch game: $e');
+      _setLoading(false);
+      return false;
+    }
+  }
+
+  // Clear current game data
+  void clearGame() {
+    _currentGame = null;
+    _currentGameId = null;
+    _gameSubscription?.cancel();
+    _gameSubscription = null;
+    _clearError();
+    notifyListeners();
+  }
+
 
   void _setLoading(bool loading) {
     _isLoading = loading;
@@ -162,5 +412,11 @@ class GameProvider extends ChangeNotifier {
   void _clearError() {
     _error = null;
     notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _gameSubscription?.cancel();
+    super.dispose();
   }
 }

--- a/lib/features/game/provider/player_provider.dart
+++ b/lib/features/game/provider/player_provider.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/foundation.dart';
+import '../models/player_model.dart';
+
+class PlayerProvider extends ChangeNotifier {
+  PlayerModel? _currentPlayer;
+  bool _isHost = false;
+  String? _currentGameId;
+
+  // Getters
+  PlayerModel? get currentPlayer => _currentPlayer;
+  bool get isHost => _isHost;
+  String? get currentGameId => _currentGameId;
+  bool get hasPlayer => _currentPlayer != null;
+  bool get isInGame => _currentGameId != null && _currentPlayer != null;
+
+  // Set the current player (used when hosting or joining a game)
+  void setCurrentPlayer(PlayerModel player, String gameId, {bool isHost = false}) {
+    _currentPlayer = player;
+    _currentGameId = gameId;
+    _isHost = isHost;
+    notifyListeners();
+  }
+
+  // Update player information
+  void updatePlayer(PlayerModel updatedPlayer) {
+    if (_currentPlayer != null) {
+      _currentPlayer = updatedPlayer;
+      notifyListeners();
+    }
+  }
+
+  // Update player's inFor amount
+  void updatePlayerBuyIn(int newAmount) {
+    if (_currentPlayer != null) {
+      _currentPlayer = _currentPlayer!.copyWith(inFor: newAmount);
+      notifyListeners();
+    }
+  }
+
+  // Update player's online status
+  void updatePlayerOnlineStatus(bool isOnline) {
+    if (_currentPlayer != null) {
+      _currentPlayer = _currentPlayer!.copyWith(isOnline: isOnline);
+      notifyListeners();
+    }
+  }
+
+  // Update player's payment status
+  void updatePlayerPaymentStatus(bool hasPaid) {
+    if (_currentPlayer != null) {
+      _currentPlayer = _currentPlayer!.copyWith(hasPaid: hasPaid);
+      notifyListeners();
+    }
+  }
+
+  // Clear current player (used when leaving game or logging out)
+  void clearPlayer() {
+    _currentPlayer = null;
+    _currentGameId = null;
+    _isHost = false;
+    notifyListeners();
+  }
+
+  // Check if current player is the host of the current game
+  bool isCurrentPlayerHost() {
+    return _isHost && _currentPlayer?.isHost == true;
+  }
+
+  // Get player ID
+  String? get playerId => _currentPlayer?.id;
+
+  // Get player name
+  String? get playerName => _currentPlayer?.name;
+
+  // Get player's buy-in amount
+  int? get playerBuyIn => _currentPlayer?.inFor;
+
+  // Debug method
+  void debugState() {
+    if (kDebugMode) {
+      print('PlayerProvider Debug State:');
+      print('  - currentPlayer: ${_currentPlayer?.id} (${_currentPlayer?.name})');
+      print('  - currentGameId: $_currentGameId');
+      print('  - isHost: $_isHost');
+      print('  - hasPlayer: $hasPlayer');
+      print('  - isInGame: $isInGame');
+    }
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'firebase_options.dart';
-import 'core/services/venmo_service.dart';
 import 'features/game/pages/end_game_page.dart';
 import 'features/game/models/player_model.dart';
+import 'features/game/models/game_model.dart';
+import 'features/game/pages/during_game_page.dart';
 
 import 'features/game/pages/host_game_page.dart';
 import 'features/game/pages/join_game_page.dart';
@@ -28,8 +29,28 @@ class PokerApp extends StatelessWidget {
       routes: {
         '/host': (_) => HostGamePage(),
         '/join': (_) => JoinGamePage(),
-        '/during_host': (_) => DuringGameHostPage(),
-        '/during_player': (_) => DuringGamePlayerPage(),
+        '/during_host': (_) => DuringGamePage(
+          game: _createSampleGame(),
+          currentPlayer: const PlayerModel(
+            id: 'host_player',
+            name: 'Host Player',
+            inFor: 100,
+            isHost: true,
+            isOnline: true,
+            hasPaid: true,
+          ),
+        ),
+        '/during_player': (_) => DuringGamePage(
+          game: _createSampleGame(),
+          currentPlayer: const PlayerModel(
+            id: 'regular_player',
+            name: 'Regular Player',
+            inFor: 100,
+            isHost: false,
+            isOnline: true,
+            hasPaid: true,
+          ),
+        ),
         '/end_host': (_) => EndGameHostPage(),
         
         '/end_player': (_) => EndGamePage(
@@ -84,18 +105,54 @@ class MainPage extends StatelessWidget {
   }
 }
 
-class DuringGameHostPage extends StatelessWidget {
-  const DuringGameHostPage({super.key});
-
-  @override
-  Widget build(BuildContext context) => Scaffold(body: Center(child: Text("During Game - Host")));
-}
-
-class DuringGamePlayerPage extends StatelessWidget {
-  const DuringGamePlayerPage({super.key});
-
-  @override
-  Widget build(BuildContext context) => Scaffold(body: Center(child: Text("During Game - Player")));
+GameModel _createSampleGame() {
+  return GameModel(
+    id: 'ABC1234',
+    hostId: 'host_player',
+    hostName: 'Host Player',
+    players: [
+      const PlayerModel(
+        id: 'host_player',
+        name: 'Host Player',
+        inFor: 100,
+        isHost: true,
+        isOnline: true,
+        hasPaid: true,
+      ),
+      const PlayerModel(
+        id: 'player1',
+        name: 'Alice Johnson',
+        inFor: 100,
+        isHost: false,
+        isOnline: true,
+        hasPaid: true,
+      ),
+      const PlayerModel(
+        id: 'player2',
+        name: 'Bob Smith',
+        inFor: 150,
+        isHost: false,
+        isOnline: true,
+        hasPaid: false,
+      ),
+      const PlayerModel(
+        id: 'player3',
+        name: 'Carol Davis',
+        inFor: 100,
+        isHost: false,
+        isOnline: false,
+        hasPaid: true,
+      ),
+    ],
+    status: GameStatus.playing,
+    type: GameType.cash,
+    maxPlayers: 8,
+    currentPlayers: 4,
+    buyIn: 100,
+    createdAt: DateTime.now().subtract(const Duration(hours: 2)),
+    startedAt: DateTime.now().subtract(const Duration(hours: 1, minutes: 30)),
+    venmoUsername: 'renaaron',
+  );
 }
 
 class EndGameHostPage extends StatelessWidget {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,13 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:provider/provider.dart';
 import 'firebase_options.dart';
 import 'features/game/pages/end_game_page.dart';
-import 'features/game/models/player_model.dart';
-import 'features/game/models/game_model.dart';
 import 'features/game/pages/during_game_page.dart';
-
 import 'features/game/pages/host_game_page.dart';
 import 'features/game/pages/join_game_page.dart';
+import 'features/game/provider/game_provider.dart';
+import 'features/game/provider/player_provider.dart';
+import 'core/services/firebase_service.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized(); // required for async setup
@@ -22,50 +23,22 @@ class PokerApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Poker App',
-      theme: ThemeData(primarySwatch: Colors.blue),
-      home: MainPage(),
-      routes: {
-        '/host': (_) => HostGamePage(),
-        '/join': (_) => JoinGamePage(),
-        '/during_host': (_) => DuringGamePage(
-          game: _createSampleGame(),
-          currentPlayer: const PlayerModel(
-            id: 'host_player',
-            name: 'Host Player',
-            inFor: 100,
-            isHost: true,
-            isOnline: true,
-            hasPaid: true,
-          ),
-        ),
-        '/during_player': (_) => DuringGamePage(
-          game: _createSampleGame(),
-          currentPlayer: const PlayerModel(
-            id: 'regular_player',
-            name: 'Regular Player',
-            inFor: 100,
-            isHost: false,
-            isOnline: true,
-            hasPaid: true,
-          ),
-        ),
-        '/end_host': (_) => EndGameHostPage(),
-        
-        '/end_player': (_) => EndGamePage(
-          player: const PlayerModel(
-            id: 'test_player',
-            name: 'John Doe',
-            inFor: 100,
-            isHost: false,
-            isOnline: true,
-            hasPaid: true,
-          ),
-          hostVenmoUsername: 'renaaron',
-          initialBuyIn: 100, // Initial buy-in from game data
-        ),
-      },
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider(create: (context) => GameProvider(FirebaseService())),
+        ChangeNotifierProvider(create: (context) => PlayerProvider()),
+      ],
+      child: MaterialApp(
+        title: 'Poker App',
+        theme: ThemeData(primarySwatch: Colors.blue),
+        home: MainPage(),
+        routes: {
+          '/host': (_) => HostGamePage(),
+          '/join': (_) => JoinGamePage(),
+          '/during_game': (_) => DuringGamePage(),
+          '/end_game': (_) => EndGamePage(),
+        },
+      ),
     );
   }
 }
@@ -74,11 +47,8 @@ class MainPage extends StatelessWidget {
   final List<Map<String, String>> pages = [
     {'label': 'Host Game', 'route': '/host'},
     {'label': 'Join Game', 'route': '/join'},
-    {'label': 'During Game - Host', 'route': '/during_host'},
-    {'label': 'During Game - Player', 'route': '/during_player'},
-    {'label': 'End Game - Host', 'route': '/end_host'},
-    {'label': 'End Game - Player', 'route': '/end_player'},
-
+    {'label': 'During Game (Demo)', 'route': '/during_game'},
+    {'label': 'End Game (Demo)', 'route': '/end_game'},
   ];
 
   MainPage({super.key});
@@ -105,62 +75,6 @@ class MainPage extends StatelessWidget {
   }
 }
 
-GameModel _createSampleGame() {
-  return GameModel(
-    id: 'ABC1234',
-    hostId: 'host_player',
-    hostName: 'Host Player',
-    players: [
-      const PlayerModel(
-        id: 'host_player',
-        name: 'Host Player',
-        inFor: 100,
-        isHost: true,
-        isOnline: true,
-        hasPaid: true,
-      ),
-      const PlayerModel(
-        id: 'player1',
-        name: 'Alice Johnson',
-        inFor: 100,
-        isHost: false,
-        isOnline: true,
-        hasPaid: true,
-      ),
-      const PlayerModel(
-        id: 'player2',
-        name: 'Bob Smith',
-        inFor: 150,
-        isHost: false,
-        isOnline: true,
-        hasPaid: false,
-      ),
-      const PlayerModel(
-        id: 'player3',
-        name: 'Carol Davis',
-        inFor: 100,
-        isHost: false,
-        isOnline: false,
-        hasPaid: true,
-      ),
-    ],
-    status: GameStatus.playing,
-    type: GameType.cash,
-    maxPlayers: 8,
-    currentPlayers: 4,
-    buyIn: 100,
-    createdAt: DateTime.now().subtract(const Duration(hours: 2)),
-    startedAt: DateTime.now().subtract(const Duration(hours: 1, minutes: 30)),
-    venmoUsername: 'renaaron',
-  );
-}
-
-class EndGameHostPage extends StatelessWidget {
-  const EndGameHostPage({super.key});
-
-  @override
-  Widget build(BuildContext context) => Scaffold(body: Center(child: Text("End Game - Host")));
-}
 
 
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -464,6 +464,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.4.6"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   package_config:
     dependency: transitive
     description:
@@ -496,6 +504,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
+  provider:
+    dependency: "direct main"
+    description:
+      name: provider
+      sha256: "4e82183fa20e5ca25703ead7e05de9e4cceed1fbd1eadc1ac3cb6f565a09f272"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.5+1"
   pub_semver:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   freezed_annotation: ^3.0.0
   json_annotation: ^4.9.0
   url_launcher: ^6.2.4
+  provider: ^6.1.2
 
 
 dev_dependencies:


### PR DESCRIPTION
## Overview:
- This branch adds support for the "During game" screen
- It also creates a game and player state tracker to connect the rest of the workflow to actual database data

## Changes:
1) Creates the `during_game_page.dart`, which shows active players, total buy-ins and other info
   - Screen differs depending on if the player is the host or not
<img width="1926" height="1240" alt="image" src="https://github.com/user-attachments/assets/bf2c127c-e2c8-4011-9398-d2fb951b2372" />

2) Uses a provider pattern with a ChangeNotifier to share current player and current game state with the various screens in the application

3) Changes some of the end game screen logic based on final stack value